### PR TITLE
Allow configuring type accessibility

### DIFF
--- a/src/Wcwidth/Unicode.cs
+++ b/src/Wcwidth/Unicode.cs
@@ -7,7 +7,12 @@ namespace Wcwidth
     /// Represents a Unicode version.
     /// </summary>
     [SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores")]
-    public enum Unicode
+#if WCWIDTH_VISIBILITY_INTERNAL
+    internal
+#else
+    public
+#endif
+    enum Unicode
     {
         /// <summary>
         /// Unicode version 4.1.0.

--- a/src/Wcwidth/UnicodeCalculator.cs
+++ b/src/Wcwidth/UnicodeCalculator.cs
@@ -49,7 +49,12 @@ namespace Wcwidth
     /// <summary>
     /// A utility for calculating the width of Unicode characters.
     /// </summary>
-    public static class UnicodeCalculator
+#if WCWIDTH_VISIBILITY_INTERNAL
+    internal
+#else
+    public
+#endif
+    static class UnicodeCalculator
     {
         private const Unicode Latest = Unicode.Version_13_0_0;
 


### PR DESCRIPTION
We are [consuming](https://github.com/dotnet/templating/pull/3922) `WcWidth.Sources` package to be used with `dotnet new` command in .NET CLI.
However, some types have public visibility, which eventually ends up being exposed in our generated assemblies.

This PR adds preprocessor directives to make the accessibility configurable if needed (inspired by a very similar fix [here](https://github.com/xunit/assert.xunit/blob/main/IdentityAsserts.cs#L9-L13)).